### PR TITLE
removed unnecessary uri decode/encode from getLatestAccessTimeStamp

### DIFF
--- a/lib/firefoxos.js
+++ b/lib/firefoxos.js
@@ -35,5 +35,5 @@ function saveTimeStamp(date){
 
 function getLatestAccessTimeStamp() {
     var sKey = "LastAccess";
-    return decodeURIComponent(document.cookie.replace(new RegExp("(?:(?:^|.*;)\\s*" + encodeURIComponent(sKey).replace(/[\-\.\+\*]/g, "\\$&") + "\\s*\\=\\s*([^;]*).*$)|^.*$"), "$1")) || null;;
+    return document.cookie.replace(new RegExp("(?:(?:^|.*;)\\s*" + sKey + "\\s*\\=\\s*([^;]*).*$)|^.*$"), "$1") || null;;
 }


### PR DESCRIPTION
Unnecessary dead code. uri encoding not used in date stored in cookie.
