### PR TITLE
Don't record information if the request failed.

### DIFF
--- a/lib/firefoxos.js
+++ b/lib/firefoxos.js
@@ -16,15 +16,21 @@
 		}
 		data = data ? data.toString() : null;
 		var xhr = new XMLHttpRequest(),
-			ajaxCallback = function () {
+			successCallback = function () {
+				if (xhr.status === null || xhr.status === 0 || xhr.status === 404) {
+					return errorCallback();
+				}
 				recordLatency(data ? data.length : 0, startedAt, function () {
 					if (typeof callback === 'function') {
 						callback(xhr.response, xhr.status, xhr);
 					}
-					if (xhr.status !== null) {
-						context.dispatchEvent(event);
-					}
+					context.dispatchEvent(event);
 				}, origin);
+			},
+			errorCallback = function(){
+				if (typeof callback === 'function') {
+					callback(xhr.response, xhr.status, xhr);
+				}
 			};
 		BatteryManager.onchargingchange = function () {
 			// ensure we are actually charging and did not just 
@@ -35,8 +41,8 @@
 
 		};
 
-		xhr.onload = ajaxCallback;
-		xhr.onerror = ajaxCallback;
+		xhr.onload = successCallback;
+		xhr.onerror = errorCallback;
 		xhr.open(data !== null ? 'POST' : 'GET', url);
 
 		xhr.send(data || null);

--- a/test/spec/latency.spec.js
+++ b/test/spec/latency.spec.js
@@ -28,6 +28,17 @@ describe('work with last access time stamp', function () {
 			done();
 		});
 	});
+	
+	it('should not change last access if the request failed', function(done){
+		AL.getLatestAccessTimeStamp(function(firsttimestamp){
+			AL.ajax('example.com', {cats: 'infinitey'}, function () {
+				AL.getLatestAccessTimeStamp(function(secondtimestamp){
+					expect(firsttimestamp).toEqual(secondtimestamp);
+					done();
+				});
+			});
+		});
+	});
 });
 
 describe('keeps a history of requests', function () {


### PR DESCRIPTION
Split out onload vs onerror for XHR.