### PR TITLE
Added historical request count based on localforage id of successful req...

### DIFF
--- a/examples/battest/app.js
+++ b/examples/battest/app.js
@@ -4,6 +4,7 @@ window.addEventListener('load', function () {
 	window.addEventListener('network-ready', updatePendingRequestCount);
 	updatePendingRequestCount();
 	setInterval(updatePendingRequestCount, 100);
+	setInterval(updateTotalRequests, 100);
 });
 
 function fireNetwork(){
@@ -19,5 +20,15 @@ function updatePendingRequestCount() {
 	var elem = document.getElementById('pendingRequestCount');
 	if (elem) {
 		elem.innerHTML = AL.getPendingRequests().length;
+	}
+}
+
+function updateTotalRequests() {
+	var elem = document.getElementById('totalRequestCount');
+	if (elem) {
+		AL.getNextID(function(ID){
+			elem.innerHTML = ID -1;	
+		});
+		
 	}
 }

--- a/examples/battest/app.js
+++ b/examples/battest/app.js
@@ -2,6 +2,7 @@ window.addEventListener('load', function () {
 	document.getElementById('fireNetworkBtn').addEventListener('click', fireNetwork);
 	document.getElementById('addNonCritReq').addEventListener('click', addNonCriticalRequest);
 	window.addEventListener('network-ready', updatePendingRequestCount);
+	document.getElementById('clearHistory').addEventListener('click', clearHistory);
 	updatePendingRequestCount();
 	setInterval(updatePendingRequestCount, 100);
 	setInterval(updateTotalRequests, 100);
@@ -31,4 +32,8 @@ function updateTotalRequests() {
 		});
 		
 	}
+}
+
+function clearHistory(){
+	localforage.clear();
 }

--- a/examples/battest/index.html
+++ b/examples/battest/index.html
@@ -24,6 +24,7 @@
 		<h1>Hello World</h1>
 		<div>
 			Pending requests: <span id="pendingRequestCount"></span><br />
+			Total requests made (historical): <span id="totalRequestCount"></span><br />
 			Request URL: <br />
 			<input type="text" id="requestURL" size=45 value="https://developer.mozilla.org/search.json?q=cats"><br />
 			<button id="addNonCritReq">Add non-critical request</button>

--- a/examples/battest/index.html
+++ b/examples/battest/index.html
@@ -32,6 +32,9 @@
 		<div>
 			<button id="fireNetworkBtn">Network is ready</button>
 		</div>
+		<div>
+			<button id="clearHistory">Clear history</button>
+		</div>
 	</body>
 
 </html>


### PR DESCRIPTION
...uests. @TheBosZ This idea i came up with exposes some bugs of our library.

1. Making more than 2 requests (Try several more than 2) will not result in a correct count. Are the requests failing, or is it a bug in our localforage history or my getNextID?

2. A unsuccessful request (Adding a garbage request) will stall the queue and prevent it from being emptied when it hits that request. It seems the queue is only emptied when it hits the last request and does not remove the requests item by item, Try adding 2 known good urls (given) and then add a garbage url. Request count goes up 2, pending count stays the same, hitting network ready again will duplicate the 2 good requests in the stalled queue.