### PR TITLE
Cenglish/selenium download

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_install:
  - npm install -g nightwatch
  - sudo apt-get update
  - sudo apt-get install -y firefox
+ - wget https://selenium-release.storage.googleapis.com/2.44/selenium-server-standalone-2.44.0.jar
 install: 
  - npm install
  - bower install

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ before_install:
  - npm install -g nightwatch
  - sudo apt-get update
  - sudo apt-get install -y firefox
- - wget https://selenium-release.storage.googleapis.com/2.44/selenium-server-standalone-2.44.0.jar
 install: 
  - npm install
  - bower install

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -88,7 +88,7 @@ module.exports = function (grunt) {
 		nightwatch: {
 			options: {
 				standalone: true,
-				jar_path: 'selenium-server-standalone-2.44.0.jar',
+				jar_url: 'https://selenium-release.storage.googleapis.com/2.44/selenium-server-standalone-2.44.0.jar',
 				  custom_assertions_path: 'nightwatch_assertions/',
 				src_folders: ['examples/tests/']
 


### PR DESCRIPTION
Selenium will now automatically download when 'grunt build', 'grunt test' or 'grunt nightwatch' are run. For some reason known only to Travis this method doesn't work, so the .travis.yml file still contains the wget to obtain a copy first before running the tests.