### PR TITLE
Cenglish/remove grunt nightwatch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ before_install:
  - npm install -g nightwatch
  - sudo apt-get update
  - sudo apt-get install -y firefox
- - wget https://selenium-release.storage.googleapis.com/2.44/selenium-server-standalone-2.44.0.jar
 install: 
  - npm install
  - bower install
@@ -17,3 +16,4 @@ before_script:
  - grunt build
 script:
  - grunt test
+ - nightwatch -t examples/tests/test.js

--- a/README.md
+++ b/README.md
@@ -40,11 +40,13 @@ Nightwatch (http://nightwatchjs.org/) is used as the E2E testing solution for th
 
 `npm install -g nightwatch`
 
-Selenium (https://selenium-release.storage.googleapis.com/2.44/selenium-server-standalone-2.44.0.jar) is also needed to run the Nightwatch tests. The included configuration file will automatically start Selenium when the tests are run.
+Selenium is also needed to run the Nightwatch tests. Grunt will automatically download Selenium (if it does not already exist in the directory) whenever `grunt-build` is executed. Should you want to download Selenium manually, you may do so from: https://selenium-release.storage.googleapis.com/2.44/selenium-server-standalone-2.44.0.jar
 
-Grunt is configured to run Nightwatch whenever `grunt build` or `grunt test` are executed. On `grunt build` the `examples/tests/test.js` folder is edited to the change the path to the battest app's `index.html` file to be the absolute path to the copy on your local machine.
+The included configuration file will automatically start Selenium when the tests are run.
 
-You can use `nightwatch -t examples/tests/test.js` to run the tests manually, if desired.
+On `grunt build` the `examples/tests/test.js` folder is edited to the change the path to the battest app's `index.html` file to be the absolute path to the copy on your local machine. Therefore it is required to run `grunt-build` at least once prior to trying to executing the Nightwatch tests (or else manually edit the file yourself).
+
+You can use `nightwatch -t examples/tests/test.js` to run the tests.
 
 #### NetBeans
 ##### Downloading NetBeans and Loading Project  

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -14,7 +14,7 @@ module.exports = function (grunt) {
 	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
 	grunt.loadNpmTasks('grunt-contrib-copy');
 	grunt.loadNpmTasks('grunt-replace');
-	grunt.loadNpmTasks('grunt-nightwatch');
+	grunt.loadNpmTasks('grunt-downloadfile');
 	var config = {
 		app: 'lib',
 		dist: 'dist'
@@ -85,20 +85,15 @@ module.exports = function (grunt) {
 				}]
 			}
 		},
-		nightwatch: {
-			options: {
-				standalone: true,
-				jar_url: 'https://selenium-release.storage.googleapis.com/2.44/selenium-server-standalone-2.44.0.jar',
-				  custom_assertions_path: 'nightwatch_assertions/',
-				src_folders: ['examples/tests/']
-
-			}
+		downloadfile: {
+			files: [
+				'https://selenium-release.storage.googleapis.com/2.44/selenium-server-standalone-2.44.0.jar'
+			]
 		}
 	});
 	
 	grunt.registerTask('test', [
-		'karma:unit',
-		'nightwatch'
+		'karma:unit'
 	]);
 	
 	grunt.registerTask('build', [
@@ -108,7 +103,7 @@ module.exports = function (grunt) {
 		'karma:unit',
 		'copy:main',
 		'replace',
-		'nightwatch'
+		'downloadfile'
 	]);
 
 	grunt.registerTask('default', [

--- a/nightwatch.json
+++ b/nightwatch.json
@@ -1,0 +1,45 @@
+{
+  "src_folders" : ["examples/tests"],
+  "output_folder" : "examples/tests/reports",
+  "custom_commands_path" : "",
+  "custom_assertions_path" : "nightwatch_assertions/",
+  "globals_path" : "",
+  
+  "selenium" : {
+    "start_process" : true,
+    "server_path" : "selenium-server-standalone-2.44.0.jar",
+    "log_path" : false,
+    "host" : "127.0.0.1",
+    "port" : 4444,
+    "cli_args" : {
+      "webdriver.chrome.driver" : "",
+      "webdriver.ie.driver" : ""
+    }  
+  },
+  
+  "test_settings" : {
+    "default" : {
+      "launch_url" : "http://localhost",
+      "selenium_port"  : 4444,
+      "selenium_host"  : "localhost",
+      "silent": true,
+      "screenshots" : {
+        "enabled" : false,
+        "path" : ""
+      },
+      "desiredCapabilities": {
+        "browserName": "firefox",
+        "javascriptEnabled": true,
+        "acceptSslCerts": true
+      }
+    },
+    
+    "chrome" : {
+      "desiredCapabilities": {
+        "browserName": "chrome",
+        "javascriptEnabled": true,
+        "acceptSslCerts": true
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "grunt-contrib-copy": "*",
     "grunt-contrib-jshint": "*",
     "grunt-contrib-uglify": "*",
+    "grunt-downloadfile": "*",
     "grunt-karma": "*",
     "grunt-replace": "*",
-    "grunt-nightwatch": "*",
     "grunt-string-replace": "^1.0.0",
     "jshint-stylish": "^0.4.0",
     "karma": "^0.12.16",
@@ -22,8 +22,7 @@
     "karma-phantomjs-launcher": "^0.1.4",
     "karma-script-launcher": "^0.1.0",
     "load-grunt-tasks": "^0.4.0",
-    "matchdep": "^0.3.0",
-    "nightwatch": "*"
+    "matchdep": "^0.3.0"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
Removed the grunt-nightwatch package, due to the errors we were having with it on Windows machines. Because that package was responsible for downloading Selenium, added the package 'grunt-downloadfile' to download it whenever we run `grunt-build`, as well as adding back in the nightwatch.json configuration file.

Updated the package.json file to reflect this new dependency, as well as remove the 'grunt-nightwatch' dependency.

Updated the .travis.yml file to reflect this changes in how Selenium is downloaded and Nightwatch is run.

Updated the README.md file to reflect these changes.